### PR TITLE
feat: 경로 변경시 맨 위로 스크롤 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,11 +17,13 @@ import MapPage from "./pages/MapPage/MapPage";
 import MapHistoryView from "./pages/MapHistoryView/MapHistoryView";
 import NotFound from "./pages/NotFoundPage/NotFoundPage";
 import MyPage from "./pages/MyPage/MyPage";
+import ScrollToTopOnNavigation from "./components/ScrollToTop/ScrollToTopOnNavigation";
 
 function App() {
   return (
     <AuthProvider>
       <BrowserRouter>
+        <ScrollToTopOnNavigation />
         <Routes>
           <Route element={<Layout />}>
             <Route path="/" element={<Home />} />

--- a/src/components/ScrollToTop/ScrollToTopOnNavigation.jsx
+++ b/src/components/ScrollToTop/ScrollToTopOnNavigation.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+/**
+ * 페이지 이동 시 스크롤을 맨 위로 이동시키는 컴포넌트
+ */
+const ScrollToTopOnNavigation = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTopOnNavigation;
+


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/HomePage -> main

### 변경 사항
사이드바를 통해 메뉴를 클릭하여 다른 페이지로 이동하거나 새로고침할 때 화면이 항상 맨 위에서 시작되도록 구현했습니다.
(ScrollToTopOnNavigation 컴포넌트 App.jsx에 추가됨)

### 테스트 결과
관광코스 페이지로 먼저 가서 맨 밑으로 스크롤한 후 사이드바를 열어 다른 메뉴로 이동하는 방법으로 확인하시면 됩니다.